### PR TITLE
Enable receiver-dependent tracking mode substitution

### DIFF
--- a/source/gnss/gnssReceiver.h
+++ b/source/gnss/gnssReceiver.h
@@ -103,10 +103,13 @@ public:
   /** @brief Rotation from local/body frame to left-handed antenna system (usually north, east, up). */
   Transform3d local2antennaFrame(UInt idEpoch) const {return local2antenna.at(idEpoch);}
 
-  /** @brief Transformation matrix for observed (composed) types from orignal transmitted types.
+  /** @brief Transformation matrix for observed (composed) types from original transmitted types.
   * E.g. C2DG = C1CG - C1WG + C2WG.
   * Returns the @a typesTrans and the transformation matrix @a A (dimension: types.size() times typesTrans.size()). */
   virtual void signalComposition(UInt /*idEpoch*/, const std::vector<GnssType> &types, std::vector<GnssType> &typesTrans, Matrix &A) const;
+
+  /** @brief Substitute tracking attribute of signal type depending on receiver type */
+  GnssType substituteSignal(GnssType type) const;
 
   /** @brief All observations between receiver and transmitter at one epoch. */
   GnssObservation *observation(UInt idTrans, UInt idEpoch) const;
@@ -120,7 +123,7 @@ public:
   /** @brief Delete observation. */
   void deleteObservation(UInt idTrans, UInt idEpoch);
 
-  /** @brief Delete alle empty tracks (and ambiguities). */
+  /** @brief Delete all empty tracks (and ambiguities). */
   void deleteEmptyTracks();
 
   // Preprocessing
@@ -140,6 +143,8 @@ public:
   };
 
   void preprocessingInfo(const std::string &info, UInt countEpochs=NULLINDEX, UInt countObservations=NULLINDEX, UInt countTracks=NULLINDEX);
+
+
 
   /** @brief Reads observations from a file. Member variable @a times must be set.
   * Initializes observations. Receiver and Transmitter positions, orientations, ... must be initialized beforehand.
@@ -167,7 +172,7 @@ public:
   * Disable receiver at epoch if @p outlierRatio or more of the observed satellites have gross code outliers. */
   void disableEpochsWithGrossCodeObservationOutliers(ObservationEquationList &eqn, Double threshold, Double outlierRatio=0.5);
 
-  /** @brief Create tracks with continously identical phase observations.
+  /** @brief Create tracks with continuously identical phase observations.
   * Tracks may contain gaps but must contain observations in at least @p minObsCountPerTrack epochs.
   * Extra types are included (e.g. L5*G), but tracks must have at least two others phases at different frequencies.*/
   void createTracks(const std::vector<GnssTransmitterPtr> &transmitters, UInt minObsCountPerTrack, const std::vector<GnssType> &extraTypes={});


### PR DESCRIPTION
RINEXv3 signal code attributes are automatically substituted depending on the receiver type for RINEX generation